### PR TITLE
Add `getMultipleAccounts` RPC method

### DIFF
--- a/rpc/get_multiple_accounts.go
+++ b/rpc/get_multiple_accounts.go
@@ -1,0 +1,65 @@
+package rpc
+
+import (
+	"context"
+)
+
+// GetMultipleAccountsConfigEncoding is account's data encode format
+type GetMultipleAccountsConfigEncoding string
+
+const (
+	// GetMultipleAccountConfigEncodingBase58 limited to Account data of less than 128 bytes
+	GetMultipleAccountsConfigEncodingBase58     GetMultipleAccountsConfigEncoding = "base58"
+	GetMultipleAccountsConfigEncodingJsonParsed GetMultipleAccountsConfigEncoding = "jsonParsed"
+	GetMultipleAccountsConfigEncodingBase64     GetMultipleAccountsConfigEncoding = "base64"
+	GetMultipleAccountsConfigEncodingBase64Zstd GetMultipleAccountsConfigEncoding = "base64+zstd"
+)
+
+// GetMultipleAccountsConfig is an option config for `getAccountInfo`
+type GetMultipleAccountsConfig struct {
+	Commitment Commitment                          `json:"commitment,omitempty"`
+	Encoding   GetMultipleAccountsConfigEncoding   `json:"encoding,omitempty"`
+	DataSlice  *GetMultipleAccountsConfigDataSlice `json:"dataSlice,omitempty"`
+}
+
+// GetMultipleAccountsResponse is a full raw rpc response of `getAccountInfo`
+type GetMultipleAccountsResponse struct {
+	GeneralResponse
+	Result GetMultipleAccountsResult `json:"result"`
+}
+
+// GetMultipleAccountsConfigDataSlice is a part of GetAccountInfoConfig
+type GetMultipleAccountsConfigDataSlice struct {
+	Offset uint64 `json:"offset,omitempty"`
+	Length uint64 `json:"length,omitempty"`
+}
+
+// GetMultipleAccountsResult is rpc result of `getAccountInfo`
+type GetMultipleAccountsResult struct {
+	Context Context                          `json:"context"`
+	Value   []GetMultipleAccountsResultValue `json:"value"`
+}
+
+// GetMultipleAccountsResultValue is rpc result of `getAccountInfo`
+type GetMultipleAccountsResultValue struct {
+	Lamports  uint64      `json:"lamports"`
+	Owner     string      `json:"owner"`
+	Excutable bool        `json:"excutable"`
+	RentEpoch uint64      `json:"rentEpoch"`
+	Data      interface{} `json:"data"`
+}
+
+// GetMultipleAccounts returns all information associated with the account of provided Pubkey
+func (c *RpcClient) GetMultipleAccounts(ctx context.Context, base58Addrs []string) (GetMultipleAccountsResponse, error) {
+	return c.processGetMultipleAccounts(c.Call(ctx, "getMultipleAccounts", base58Addrs))
+}
+
+// GetMultipleAccounts returns all information associated with the account of provided Pubkey
+func (c *RpcClient) GetMultipleAccountsWithConfig(ctx context.Context, base58Addrs []string, cfg GetMultipleAccountsConfig) (GetMultipleAccountsResponse, error) {
+	return c.processGetMultipleAccounts(c.Call(ctx, "getMultipleAccounts", base58Addrs, cfg))
+}
+
+func (c *RpcClient) processGetMultipleAccounts(body []byte, rpcErr error) (res GetMultipleAccountsResponse, err error) {
+	err = c.processRpcCall(body, rpcErr, &res)
+	return
+}

--- a/rpc/get_multiple_accounts_test.go
+++ b/rpc/get_multiple_accounts_test.go
@@ -1,0 +1,364 @@
+package rpc
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetMultipleAccounts(t *testing.T) {
+	tests := []testRpcCallParam{
+		{
+			RequestBody:  `{"jsonrpc":"2.0", "id":1, "method":"getMultipleAccounts", "params":[["RNfp4xTbBb4C3kcv2KqtAj8mu4YhMHxqm1Skg9uchZ7"]]}`,
+			ResponseBody: `{"jsonrpc":"2.0","result":{"context":{"slot":77317716},"value":[{"data":"","executable":false,"lamports":21474700400,"owner":"11111111111111111111111111111111","rentEpoch":178}]},"id":1}`,
+			RpcCall: func(rc RpcClient) (interface{}, error) {
+				return rc.GetMultipleAccounts(
+					context.Background(),
+					[]string{"RNfp4xTbBb4C3kcv2KqtAj8mu4YhMHxqm1Skg9uchZ7"},
+				)
+			},
+			ExpectedResponse: GetMultipleAccountsResponse{
+				GeneralResponse: GeneralResponse{
+					JsonRPC: "2.0",
+					ID:      1,
+					Error:   nil,
+				},
+				Result: GetMultipleAccountsResult{
+					Context: Context{
+						Slot: 77317716,
+					},
+					Value: []GetMultipleAccountsResultValue{
+						{
+							Lamports:  21474700400,
+							Owner:     "11111111111111111111111111111111",
+							Excutable: false,
+							RentEpoch: 178,
+							Data:      "",
+						},
+					},
+				},
+			},
+			ExpectedError: nil,
+		},
+		{
+			RequestBody:  `{"jsonrpc":"2.0", "id":1, "method":"getMultipleAccounts", "params":[["FaTGhPTgKeZZzQwLenoxn2VZXPWV1FpjQ1AQe77JUeJw"]]}`,
+			ResponseBody: `{"jsonrpc":"2.0","result":{"context":{"slot":77382573},"value":[null]},"id":1}`,
+			RpcCall: func(rc RpcClient) (interface{}, error) {
+				return rc.GetMultipleAccounts(
+					context.Background(),
+					[]string{"FaTGhPTgKeZZzQwLenoxn2VZXPWV1FpjQ1AQe77JUeJw"},
+				)
+			},
+			ExpectedResponse: GetMultipleAccountsResponse{
+				GeneralResponse: GeneralResponse{
+					JsonRPC: "2.0",
+					ID:      1,
+					Error:   nil,
+				},
+				Result: GetMultipleAccountsResult{
+					Context: Context{
+						Slot: 77382573,
+					},
+					Value: []GetMultipleAccountsResultValue{
+						{},
+					},
+				},
+			},
+			ExpectedError: nil,
+		},
+		{
+			RequestBody:  `{"jsonrpc":"2.0", "id":1, "method":"getMultipleAccounts", "params":[["F5RYi7FMPefkc7okJNh21Hcsch7RUaLVr8Rzc8SQqxUb"]]}`,
+			ResponseBody: `{"jsonrpc":"2.0","result":{"context":{"slot":77317716},"value":[{"data":"DK9MyTraxAdzd5fQ2Cvpbb2CuDd3VHxAiXuVi3E9Swzr9urV1kwxJonAiZK2zQ5xyy2FqiguDwNUGtofpzWwz3UxafwMgjFS6jx82g1B7Z2tAAj","executable":false,"lamports":1461600,"owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","rentEpoch":178}]},"id":1}`,
+			RpcCall: func(rc RpcClient) (interface{}, error) {
+				return rc.GetMultipleAccounts(
+					context.Background(),
+					[]string{"F5RYi7FMPefkc7okJNh21Hcsch7RUaLVr8Rzc8SQqxUb"},
+				)
+			},
+			ExpectedResponse: GetMultipleAccountsResponse{
+				GeneralResponse: GeneralResponse{
+					JsonRPC: "2.0",
+					ID:      1,
+					Error:   nil,
+				},
+				Result: GetMultipleAccountsResult{
+					Context: Context{
+						Slot: 77317716,
+					},
+					Value: []GetMultipleAccountsResultValue{
+						{
+							Lamports:  1461600,
+							Owner:     "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+							Excutable: false,
+							RentEpoch: 178,
+							Data:      "DK9MyTraxAdzd5fQ2Cvpbb2CuDd3VHxAiXuVi3E9Swzr9urV1kwxJonAiZK2zQ5xyy2FqiguDwNUGtofpzWwz3UxafwMgjFS6jx82g1B7Z2tAAj",
+						},
+					},
+				},
+			},
+			ExpectedError: nil,
+		},
+		{
+			RequestBody:  `{"jsonrpc":"2.0", "id":1, "method":"getMultipleAccounts", "params":[["9ywX3U33UZC1HThhoBR2Ys7SiouXDkkDoH6brJApFh5D"]]}`,
+			ResponseBody: `{"jsonrpc":"2.0","error":{"code":-32600,"message":"Encoded binary (base 58) data should be less than 128 bytes, please use Base64 encoding."},"id":1}`,
+			RpcCall: func(rc RpcClient) (interface{}, error) {
+				return rc.GetMultipleAccounts(
+					context.Background(),
+					[]string{"9ywX3U33UZC1HThhoBR2Ys7SiouXDkkDoH6brJApFh5D"},
+				)
+			},
+			ExpectedResponse: GetMultipleAccountsResponse{
+				GeneralResponse: GeneralResponse{
+					JsonRPC: "2.0",
+					ID:      1,
+					Error: &ErrorResponse{
+						Code:    -32600,
+						Message: "Encoded binary (base 58) data should be less than 128 bytes, please use Base64 encoding.",
+					},
+				},
+				Result: GetMultipleAccountsResult{},
+			},
+			ExpectedError: nil,
+		},
+		{
+			RequestBody:  `{"jsonrpc":"2.0", "id":1, "method":"getMultipleAccounts", "params":[["F5RYi7FMPefkc7okJNh21Hcsch7RUaLVr8Rzc8SQqxUb"], {"commitment": "finalized"}]}`,
+			ResponseBody: `{"jsonrpc":"2.0","result":{"context":{"slot":77317716},"value":[{"data":"DK9MyTraxAdzd5fQ2Cvpbb2CuDd3VHxAiXuVi3E9Swzr9urV1kwxJonAiZK2zQ5xyy2FqiguDwNUGtofpzWwz3UxafwMgjFS6jx82g1B7Z2tAAj","executable":false,"lamports":1461600,"owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","rentEpoch":178}]},"id":1}`,
+			RpcCall: func(rc RpcClient) (interface{}, error) {
+				return rc.GetMultipleAccountsWithConfig(
+					context.Background(),
+					[]string{"F5RYi7FMPefkc7okJNh21Hcsch7RUaLVr8Rzc8SQqxUb"},
+					GetMultipleAccountsConfig{
+						Commitment: CommitmentFinalized,
+					},
+				)
+			},
+			ExpectedResponse: GetMultipleAccountsResponse{
+				GeneralResponse: GeneralResponse{
+					JsonRPC: "2.0",
+					ID:      1,
+					Error:   nil,
+				},
+				Result: GetMultipleAccountsResult{
+					Context: Context{
+						Slot: 77317716,
+					},
+					Value: []GetMultipleAccountsResultValue{
+						{
+							Lamports:  1461600,
+							Owner:     "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+							Excutable: false,
+							RentEpoch: 178,
+							Data:      "DK9MyTraxAdzd5fQ2Cvpbb2CuDd3VHxAiXuVi3E9Swzr9urV1kwxJonAiZK2zQ5xyy2FqiguDwNUGtofpzWwz3UxafwMgjFS6jx82g1B7Z2tAAj",
+						},
+					},
+				},
+			},
+			ExpectedError: nil,
+		},
+		{
+			RequestBody:  `{"jsonrpc":"2.0", "id":1, "method":"getMultipleAccounts", "params":[["F5RYi7FMPefkc7okJNh21Hcsch7RUaLVr8Rzc8SQqxUb"], {"encoding": "base64"}]}`,
+			ResponseBody: `{"jsonrpc":"2.0","result":{"context":{"slot":77317717},"value":[{"data":["AQAAAAY+cNmRV5jco+7bkTfPZMcP+vtizdOCgQUlC9drHWzeAAAAAAAAAAAJAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==","base64"],"executable":false,"lamports":1461600,"owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","rentEpoch":178}]},"id":1}`,
+			RpcCall: func(rc RpcClient) (interface{}, error) {
+				return rc.GetMultipleAccountsWithConfig(
+					context.Background(),
+					[]string{"F5RYi7FMPefkc7okJNh21Hcsch7RUaLVr8Rzc8SQqxUb"},
+					GetMultipleAccountsConfig{
+						Encoding: GetMultipleAccountsConfigEncodingBase64,
+					},
+				)
+			},
+			ExpectedResponse: GetMultipleAccountsResponse{
+				GeneralResponse: GeneralResponse{
+					JsonRPC: "2.0",
+					ID:      1,
+					Error:   nil,
+				},
+				Result: GetMultipleAccountsResult{
+					Context: Context{
+						Slot: 77317717,
+					},
+					Value: []GetMultipleAccountsResultValue{
+						{
+							Lamports:  1461600,
+							Owner:     "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+							Excutable: false,
+							RentEpoch: 178,
+							Data:      []interface{}{"AQAAAAY+cNmRV5jco+7bkTfPZMcP+vtizdOCgQUlC9drHWzeAAAAAAAAAAAJAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", "base64"},
+						},
+					},
+				},
+			},
+			ExpectedError: nil,
+		},
+		{
+			RequestBody:  `{"jsonrpc":"2.0", "id":1, "method":"getMultipleAccounts", "params":[["F5RYi7FMPefkc7okJNh21Hcsch7RUaLVr8Rzc8SQqxUb"], {"encoding": "base64+zstd"}]}`,
+			ResponseBody: `{"jsonrpc":"2.0","result":{"context":{"slot":77317717},"value":[{"data":["KLUv/QBYjQEAhAIBAAAABj5w2ZFXmNyj7tuRN89kxw/6+2LN04KBBSUL12sdbN4ACQEAAgAAGXXBEw==","base64+zstd"],"executable":false,"lamports":1461600,"owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","rentEpoch":178}]},"id":1}`,
+			RpcCall: func(rc RpcClient) (interface{}, error) {
+				return rc.GetMultipleAccountsWithConfig(
+					context.Background(),
+					[]string{"F5RYi7FMPefkc7okJNh21Hcsch7RUaLVr8Rzc8SQqxUb"},
+					GetMultipleAccountsConfig{
+						Encoding: GetMultipleAccountsConfigEncodingBase64Zstd,
+					},
+				)
+			},
+			ExpectedResponse: GetMultipleAccountsResponse{
+				GeneralResponse: GeneralResponse{
+					JsonRPC: "2.0",
+					ID:      1,
+					Error:   nil,
+				},
+				Result: GetMultipleAccountsResult{
+					Context: Context{
+						Slot: 77317717,
+					},
+					Value: []GetMultipleAccountsResultValue{
+						{
+							Lamports:  1461600,
+							Owner:     "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+							Excutable: false,
+							RentEpoch: 178,
+							Data:      []interface{}{"KLUv/QBYjQEAhAIBAAAABj5w2ZFXmNyj7tuRN89kxw/6+2LN04KBBSUL12sdbN4ACQEAAgAAGXXBEw==", "base64+zstd"},
+						},
+					},
+				},
+			},
+			ExpectedError: nil,
+		},
+		{
+			RequestBody:  `{"jsonrpc":"2.0", "id":1, "method":"getMultipleAccounts", "params":[["F5RYi7FMPefkc7okJNh21Hcsch7RUaLVr8Rzc8SQqxUb"], {"dataSlice": {"length": 32}}]}`,
+			ResponseBody: `{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params: missing field` + "`offset`" + `."},"id":1}`,
+			RpcCall: func(rc RpcClient) (interface{}, error) {
+				return rc.GetMultipleAccountsWithConfig(
+					context.Background(),
+					[]string{"F5RYi7FMPefkc7okJNh21Hcsch7RUaLVr8Rzc8SQqxUb"},
+					GetMultipleAccountsConfig{
+						DataSlice: &GetMultipleAccountsConfigDataSlice{
+							Length: 32,
+						},
+					},
+				)
+			},
+			ExpectedResponse: GetMultipleAccountsResponse{
+				GeneralResponse: GeneralResponse{
+					JsonRPC: "2.0",
+					ID:      1,
+					Error: &ErrorResponse{
+						Code:    -32602,
+						Message: `Invalid params: missing field` + "`offset`" + `.`,
+					},
+				},
+				Result: GetMultipleAccountsResult{},
+			},
+			ExpectedError: nil,
+		},
+		{
+			RequestBody:  `{"jsonrpc":"2.0", "id":1, "method":"getMultipleAccounts", "params":[["F5RYi7FMPefkc7okJNh21Hcsch7RUaLVr8Rzc8SQqxUb"], {"dataSlice": {"offset": 4}}]}`,
+			ResponseBody: `{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params: missing field` + "`length`" + `."},"id":1}`,
+			RpcCall: func(rc RpcClient) (interface{}, error) {
+				return rc.GetMultipleAccountsWithConfig(
+					context.Background(),
+					[]string{"F5RYi7FMPefkc7okJNh21Hcsch7RUaLVr8Rzc8SQqxUb"},
+					GetMultipleAccountsConfig{
+						DataSlice: &GetMultipleAccountsConfigDataSlice{
+							Offset: 4,
+						},
+					},
+				)
+			},
+			ExpectedResponse: GetMultipleAccountsResponse{
+				GeneralResponse: GeneralResponse{
+					JsonRPC: "2.0",
+					ID:      1,
+					Error: &ErrorResponse{
+						Code:    -32602,
+						Message: `Invalid params: missing field` + "`length`" + `.`,
+					},
+				},
+				Result: GetMultipleAccountsResult{},
+			},
+			ExpectedError: nil,
+		},
+		{
+			RequestBody:  `{"jsonrpc":"2.0", "id":1, "method":"getMultipleAccounts", "params":[["F5RYi7FMPefkc7okJNh21Hcsch7RUaLVr8Rzc8SQqxUb"], {"dataSlice": {"offset": 4, "length": 32}}]}`,
+			ResponseBody: `{"jsonrpc":"2.0","result":{"context":{"slot":77322439},"value":[{"data":"RNfp4xTbBb4C3kcv2KqtAj8mu4YhMHxqm1Skg9uchZ7","executable":false,"lamports":1461600,"owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","rentEpoch":178}]},"id":1}`,
+			RpcCall: func(rc RpcClient) (interface{}, error) {
+				return rc.GetMultipleAccountsWithConfig(
+					context.Background(),
+					[]string{"F5RYi7FMPefkc7okJNh21Hcsch7RUaLVr8Rzc8SQqxUb"},
+					GetMultipleAccountsConfig{
+						DataSlice: &GetMultipleAccountsConfigDataSlice{
+							Offset: 4,
+							Length: 32,
+						},
+					},
+				)
+			},
+			ExpectedResponse: GetMultipleAccountsResponse{
+				GeneralResponse: GeneralResponse{
+					JsonRPC: "2.0",
+					ID:      1,
+					Error:   nil,
+				},
+				Result: GetMultipleAccountsResult{
+					Context: Context{
+						Slot: 77322439,
+					},
+					Value: []GetMultipleAccountsResultValue{
+						{
+							Lamports:  1461600,
+							Owner:     "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+							Excutable: false,
+							RentEpoch: 178,
+							Data:      "RNfp4xTbBb4C3kcv2KqtAj8mu4YhMHxqm1Skg9uchZ7",
+						},
+					},
+				},
+			},
+			ExpectedError: nil,
+		},
+		{
+			RequestBody:  `{"jsonrpc":"2.0", "id":1, "method":"getMultipleAccounts", "params":[["F5RYi7FMPefkc7okJNh21Hcsch7RUaLVr8Rzc8SQqxUb"], {"encoding": "base64", "dataSlice": {"offset": 4, "length": 32}}]}`,
+			ResponseBody: `{"jsonrpc":"2.0","result":{"context":{"slot":77317718},"value":[{"data":["Bj5w2ZFXmNyj7tuRN89kxw/6+2LN04KBBSUL12sdbN4=","base64"],"executable":false,"lamports":1461600,"owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","rentEpoch":178}]},"id":1}`,
+			RpcCall: func(rc RpcClient) (interface{}, error) {
+				return rc.GetMultipleAccountsWithConfig(
+					context.Background(),
+					[]string{"F5RYi7FMPefkc7okJNh21Hcsch7RUaLVr8Rzc8SQqxUb"},
+					GetMultipleAccountsConfig{
+						Encoding: GetMultipleAccountsConfigEncodingBase64,
+						DataSlice: &GetMultipleAccountsConfigDataSlice{
+							Offset: 4,
+							Length: 32,
+						},
+					},
+				)
+			},
+			ExpectedResponse: GetMultipleAccountsResponse{
+				GeneralResponse: GeneralResponse{
+					JsonRPC: "2.0",
+					ID:      1,
+					Error:   nil,
+				},
+				Result: GetMultipleAccountsResult{
+					Context: Context{
+						Slot: 77317718,
+					},
+					Value: []GetMultipleAccountsResultValue{
+						{
+							Lamports:  1461600,
+							Owner:     "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+							Excutable: false,
+							RentEpoch: 178,
+							Data:      []interface{}{"Bj5w2ZFXmNyj7tuRN89kxw/6+2LN04KBBSUL12sdbN4=", "base64"},
+						},
+					},
+				},
+			},
+			ExpectedError: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			testRpcCall(t, tt)
+		})
+	}
+}


### PR DESCRIPTION
Added code to call the `getMultipleAccounts` rpc endpoint. This code is basically the same as the `getAccountInfo` rpc call but with an array of base 58 addresses and returning an array of responses.