### PR TITLE
Add support for Metaplex Token Metadata Standard v1.2.0 fields.

### DIFF
--- a/program/metaplex/tokenmeta/state.go
+++ b/program/metaplex/tokenmeta/state.go
@@ -57,7 +57,19 @@ type Metadata struct {
 	PrimarySaleHappened bool
 	IsMutable           bool
 	EditionNonce        *uint8
+	TokenStandard       *TokenStandard
+	Collection          *Collection
+	Uses                *Uses
 }
+
+type TokenStandard borsh.Enum
+
+const (
+	NonFungible TokenStandard = iota
+	FungibleAsset
+	Fungible
+	NonFungibleEdition
+)
 
 type Collection struct {
 	Verified bool

--- a/program/metaplex/tokenmeta/state_test.go
+++ b/program/metaplex/tokenmeta/state_test.go
@@ -8,6 +8,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TokenStandardPtr(v TokenStandard) *TokenStandard {
+	return &v
+}
+
+func CollectionPtr(v Collection) *Collection {
+	return &v
+}
+
+func UsesPtr(v Uses) *Uses {
+	return &v
+}
+
 func TestMetadataDeserialize(t *testing.T) {
 	type args struct {
 		data []byte
@@ -62,6 +74,16 @@ func TestMetadataDeserialize(t *testing.T) {
 				PrimarySaleHappened: true,
 				IsMutable:           false,
 				EditionNonce:        pointer.Uint8(255),
+				TokenStandard:       TokenStandardPtr(NonFungible),
+				Collection: CollectionPtr(Collection{
+					Verified: false,
+					Key:      common.PublicKey{},
+				}),
+				Uses: UsesPtr(Uses{
+					UseMethod: Burn,
+					Remaining: 0,
+					Total:     0,
+				}),
 			},
 			err: nil,
 		},


### PR DESCRIPTION
Reflect the updates in the [Metaplex Token Metadata Standard](https://docs.metaplex.com/token-metadata/specification#full-metadata-struct).