### PR TITLE
Implement SDK options and add support for a custom http client

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ import (
 func main() {
 	c := client.NewClient(rpc.MainnetRPCEndpoint)
 
+	// If you would like to customize the http client used to make the
+	// requests you could do something like this
+	// c := client.New(rpc.WithEndpoint(rpc.MainnetRPCEndpoint),rpc.WithHTTPClient(customHTTPClient))
+
 	resp, err := c.GetVersion(context.TODO())
 	if err != nil {
 		log.Fatalf("failed to version info, err: %v", err)

--- a/client/client.go
+++ b/client/client.go
@@ -24,7 +24,7 @@ func New(opts ...rpc.Option) *Client {
 }
 
 func NewClient(endpoint string) *Client {
-	return &Client{rpc.NewRpcClient(endpoint)}
+	return &Client{rpc.New(rpc.WithEndpoint(endpoint))}
 }
 
 // GetBalance fetch users lamports(SOL) balance

--- a/client/client.go
+++ b/client/client.go
@@ -17,6 +17,12 @@ type Client struct {
 	RpcClient rpc.RpcClient
 }
 
+func New(opts ...rpc.Option) *Client {
+	return &Client{
+		RpcClient: rpc.New(opts...),
+	}
+}
+
 func NewClient(endpoint string) *Client {
 	return &Client{rpc.NewRpcClient(endpoint)}
 }

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -44,11 +44,27 @@ type GeneralResponse struct {
 }
 
 type RpcClient struct {
-	endpoint string
+	endpoint   string
+	httpClient *http.Client
 }
 
 func NewRpcClient(endpoint string) RpcClient {
-	return RpcClient{endpoint: endpoint}
+	return New()
+}
+
+// New applies the given options to the rpc client being created. if no options
+// is passed, it defaults to a bare bone http client and solana mainnet
+func New(opts ...Option) RpcClient {
+
+	client := RpcClient{}
+
+	setDefaultOptions(client)
+
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	return client
 }
 
 // Call will return body of response. if http code beyond 200~300, the error also returns.
@@ -67,8 +83,7 @@ func (c *RpcClient) Call(ctx context.Context, params ...interface{}) ([]byte, er
 	req.Header.Add("Content-Type", "application/json")
 
 	// do request
-	httpclient := &http.Client{}
-	res, err := httpclient.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to do request, err: %v", err)
 	}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -48,15 +48,13 @@ type RpcClient struct {
 	httpClient *http.Client
 }
 
-func NewRpcClient(endpoint string) RpcClient {
-	return New()
-}
+func NewRpcClient(endpoint string) RpcClient { return New(WithEndpoint(endpoint)) }
 
 // New applies the given options to the rpc client being created. if no options
 // is passed, it defaults to a bare bone http client and solana mainnet
 func New(opts ...Option) RpcClient {
 
-	client := RpcClient{}
+	client := &RpcClient{}
 
 	setDefaultOptions(client)
 
@@ -64,7 +62,7 @@ func New(opts ...Option) RpcClient {
 		opt(client)
 	}
 
-	return client
+	return *client
 }
 
 // Call will return body of response. if http code beyond 200~300, the error also returns.

--- a/rpc/options.go
+++ b/rpc/options.go
@@ -5,11 +5,11 @@ import (
 )
 
 // Option is a configuration type for the Client
-type Option func(RpcClient)
+type Option func(*RpcClient)
 
 // HTTPClient is an Option type that allows you provide your own HTTP client
 func WithHTTPClient(h *http.Client) Option {
-	return func(r RpcClient) {
+	return func(r *RpcClient) {
 		r.httpClient = h
 	}
 }
@@ -17,12 +17,12 @@ func WithHTTPClient(h *http.Client) Option {
 // WithEndpoint is an Option that allows you configure the rpc endpoint that our
 // client will point to
 func WithEndpoint(endpoint string) Option {
-	return func(r RpcClient) {
+	return func(r *RpcClient) {
 		r.endpoint = endpoint
 	}
 }
 
-func setDefaultOptions(r RpcClient) {
+func setDefaultOptions(r *RpcClient) {
 	r.httpClient = &http.Client{}
 	r.endpoint = MainnetRPCEndpoint
 }

--- a/rpc/options.go
+++ b/rpc/options.go
@@ -1,0 +1,28 @@
+package rpc
+
+import (
+	"net/http"
+)
+
+// Option is a configuration type for the Client
+type Option func(RpcClient)
+
+// HTTPClient is an Option type that allows you provide your own HTTP client
+func WithHTTPClient(h *http.Client) Option {
+	return func(r RpcClient) {
+		r.httpClient = h
+	}
+}
+
+// WithEndpoint is an Option that allows you configure the rpc endpoint that our
+// client will point to
+func WithEndpoint(endpoint string) Option {
+	return func(r RpcClient) {
+		r.endpoint = endpoint
+	}
+}
+
+func setDefaultOptions(r RpcClient) {
+	r.httpClient = &http.Client{}
+	r.endpoint = MainnetRPCEndpoint
+}

--- a/rpc/options_test.go
+++ b/rpc/options_test.go
@@ -1,0 +1,29 @@
+package rpc
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOption_WithHTTPClient(t *testing.T) {
+
+	h := &http.Client{
+		Timeout: time.Minute * 20,
+	}
+
+	c := New(WithHTTPClient(h))
+
+	require.Equal(t, h, c.httpClient)
+}
+
+func TestOption_WithEndpoint(t *testing.T) {
+
+	endpoint := DevnetRPCEndpoint
+
+	c := New(WithEndpoint(endpoint))
+
+	require.Equal(t, endpoint, c.endpoint)
+}


### PR DESCRIPTION
This fixes #55 and adds the groundwork for future SDK improvements that might be needed.

I have added two new functions to the public API.

- `client.New(...opts)`
- `rpc.New(...opts)`

> there are no breaking changes