### PR TITLE
[chore] remove unecessary prefix

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -948,9 +948,9 @@ func checkJsonRpcResponse[T any](res rpc.JsonRpcResponse[T], err error) error {
 	if res.Error != nil {
 		errRes, err := json.Marshal(res.Error)
 		if err != nil {
-			return fmt.Errorf("rpc response error: %v", res.Error)
+			return fmt.Errorf("fail to marshal error: %v", res.Error)
 		}
-		return fmt.Errorf("rpc response error: %v", string(errRes))
+		return fmt.Errorf("%s", string(errRes))
 	}
 	return nil
 }


### PR DESCRIPTION
Solana return the response under the structure of

```json
{
  "code":-32009,
  "message":"Slot 135999228 was skipped, or missing in long-term storage",
  "data":null
}
```

Adding unnecessary prefix make it impossible to parse the error response to object and hard to check the error. Remove the prefix make is easier to work with error response.